### PR TITLE
Add HTTPS support for node client

### DIFF
--- a/src/httpurr/client/node.cljs
+++ b/src/httpurr/client/node.cljs
@@ -5,6 +5,7 @@
             [httpurr.protocols :as p]))
 
 (def ^:private http (js/require "http"))
+(def ^:private https (js/require "https"))
 (def ^:private url (js/require "url"))
 
 (defn url->options
@@ -71,9 +72,10 @@
       (let [{:keys [method url headers body]} request
             method (c/keyword->method method)
             headers (prepare-headers headers)
-            options (merge {:method method :headers headers}
-                           (url->options url))
-            req (.request http (clj->js options))]
+            parsed-url (url->options url)
+            https? (= "https:" (:protocol parsed-url))
+            options (merge {:method method :headers headers} parsed-url)
+            req (.request (if https? https http) (clj->js options))]
         (.setTimeout req timeout)
         (when body
           (.write req body))


### PR DESCRIPTION
The author or authors of this code dedicate any and all copyright interest
in this code to the public domain. We make this dedication for the benefit of
the public at large and to the detriment of our heirs and successors. We
intend this dedication to be an overt act of relinquishment in perpetuity of
all present and future rights to this code under copyright law.
