### PR TITLE
Docs fix

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -372,8 +372,8 @@ requests before sending them:
 
 === Auth
 
-All that is needed for basic is to encode your user and password and add it 
-to your headers along with a WWW-Authenticate header to state your realm 
+All that is needed for basic is to encode your user and password and add it
+to your headers along with a WWW-Authenticate header to state your realm
 here is an example:
 [source, clojure]
 ----

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -112,7 +112,7 @@ and the `send!` function:
 (http/get "https://api.github.com/orgs/funcool")
 
 (http/send! {:method :get
-	       :url "https://api.github.com/orgs/funcool"})
+	     :url "https://api.github.com/orgs/funcool"})
 ----
 
 === Responses

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -88,7 +88,8 @@ These functions have three arities:
 ----
 (http/get client
            "https://api.github.com/orgs/funcool"
-	   {"Content-Type" "application/json"})
+	   {:headers
+            {"Content-Type" "application/json"}})
 ----
 
 - Four arguments: like above and the fourth argument is an option map passed
@@ -98,7 +99,8 @@ These functions have three arities:
 ----
 (http/get client
            "https://api.github.com/orgs/funcool"
-	   {"Content-Type" "application/json"}
+	   {:headers
+            {"Content-Type" "application/json"}}
 	   {:timeout 2000})
 ----
 


### PR DESCRIPTION
The important change is nested the headers map under the `:headers` key. I stumbled a bit before realizing the doc example was incorrect.