### PR TITLE
Add support for nodejs chunked requests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,33 @@
   :url "http://funcool.github.io/httpurr"
   :license {:name "Public Domain" :url "http://unlicense.org"}
   :source-paths ["src"]
-  :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
-                 [org.clojure/clojurescript "1.9.225" :scope "provided"]
-                 [aleph "0.4.1" :scope "provided"]
-                 [org.clojure/test.check "0.9.0" :scope "test"]
-                 [funcool/promesa "1.5.0"]]
+  :dependencies
+    [[aleph "0.4.1" :scope "provided"]
+     [funcool/promesa "1.5.0"]
+     [lein-doo "0.1.7"]
+     [org.clojure/clojure "1.8.0" :scope "provided"]
+     [org.clojure/clojurescript "1.9.225" :scope "provided"]
+     [org.clojure/test.check "0.9.0" :scope "test"]]
+
+
+  ;;
+  :cljsbuild
+    {:builds
+      [; The path to the top-level ClojureScript source directory:
+       {:id "node-test"
+        :source-paths ["src/httpurr" "test/httpurr"]
+        ; The standard ClojureScript compiler options:
+        ; (See the ClojureScript compiler documentation for details.)
+        :compiler
+         {:output-to "target/testable.js"
+          :output-dir "target"
+          :main httpurr.test.runner
+          :target :nodejs
+          :pretty-print true}}]}
 
   :profiles
   {:dev
-   {:plugins [[lein-ancient "0.6.10"]]}})
+   {:plugins
+     [[lein-ancient "0.6.10"]
+      [lein-doo "0.1.7"]
+      [lein-cljsbuild "1.1.5"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/httpurr "0.6.2"
+(defproject funcool/httpurr "0.6.3"
   :description "A ring-inspired, promise-returning, simple Clojure(Script) HTTP client."
   :url "http://funcool.github.io/httpurr"
   :license {:name "Public Domain" :url "http://unlicense.org"}

--- a/src/httpurr/client/node.cljs
+++ b/src/httpurr/client/node.cljs
@@ -52,8 +52,6 @@
               (let [chunks (atom [])]
                 (listen msg "readable" #(swap! chunks conj (.read msg)))
                 (listen msg "end" #(callback (HttpResponse. msg (s/join "" @chunks))))))
-            (on-message [msg]
-              (callback (HttpResponse. msg)))
             (on-timeout [err]
               (callback (HttpResponseError. :timeout nil)))
             (on-client-error [err]

--- a/test/httpurr/test/runner.cljs
+++ b/test/httpurr/test/runner.cljs
@@ -1,22 +1,10 @@
 (ns httpurr.test.runner
-  (:require [cljs.test :as test]
-            [httpurr.test.test-xhr-client]
-            [httpurr.test.test-node-client]
-            [httpurr.test.test-status]))
+  (:require
+    [cljs.test :as test]
+    [doo.runner :refer-macros [doo-tests]]
+    [httpurr.test.test-node-client]
+    [httpurr.test.test-status]
+    [httpurr.test.test-xhr-client]))
 
-(enable-console-print!)
-
-(defmethod test/report [:cljs.test/default :end-run-tests]
-  [m]
-  (if (test/successful? m)
-    (.exit js/process) 0)
-    (.exit js/process) 1)
-
-(defn main
-  []
-  (test/run-tests (test/empty-env)
-                  'httpurr.test.test-xhr-client
-                  'httpurr.test.test-node-client
-                  'httpurr.test.test-status))
-
-(set! *main-cli-fn* main)
+(doo-tests 'httpurr.test.test-node-client
+           'httpurr.test.test-status)


### PR DESCRIPTION
Many changes here, still very rough.

1. I added `doo` + `cljsbuild` to `project.clj` mostly to be able to run
nodejs tests. You will notice that I dropped the other tests... I wasn't
able to get everything working together since I need to run some tests
on the browser and other tests on nodejs. Maybe you know of a good way
of doing this?
The nice thing is that if we do manage to integrate `doo`, its going to
be a breeze to test on multiple environments and it supports "watching"
for tests, which is nice when developing.

2. I added a test case to showcase the problem. Super ugly test. It
would be much better if I could get the body that the server sent and
assert that it was what the client received. Again, not sure how to do
that, maybe you do :D

3. I added the fix to node.cljs:
Essentially I just read several times instead of just once and
when the `end` event comes in I invoke the callback.