### PR TITLE
Test and Fix for #16

### DIFF
--- a/src/httpurr/client/node.cljs
+++ b/src/httpurr/client/node.cljs
@@ -49,7 +49,9 @@
             (on-response [msg]
               (let [chunks (atom [])]
                 (listen msg "readable" #(swap! chunks conj (.read msg)))
-                (listen msg "end" #(callback (HttpResponse. msg (s/join "" @chunks))))))
+                (listen msg "end" #(callback
+                                     ;concatenating the collected buffers, filtering out empty buffers
+                                     (HttpResponse. msg (.concat js/Buffer (clj->js (filter (fn [b] (not (nil? b))) @chunks))))))))
             (on-timeout [err]
               (callback (HttpResponseError. :timeout nil)))
             (on-client-error [err]

--- a/test/httpurr/test/test_node_client.cljs
+++ b/test/httpurr/test/test_node_client.cljs
@@ -15,7 +15,6 @@
 
 (def ^:private http (node/require "http"))
 (def ^:private url (node/require "url"))
-(def ^:priavte fs (node/require "fs"))
 (def ^:const port 44556)
 
 (defn- read-request

--- a/test/httpurr/test/test_node_client.cljs
+++ b/test/httpurr/test/test_node_client.cljs
@@ -101,18 +101,31 @@
                   (t/is (= (:path lreq) path))
                   (done)))))))
 
-(t/deftest send-binary
+(t/deftest send-small-binary
   (t/async done
-    (let [path "/binary"
-          uri (make-uri path)
+    (let [uri "https://clojars.org/repo/funcool/httpurr/0.6.2/httpurr-0.6.2.jar.md5"
           req {:method :get
                :url uri
                :headers {}}]
 
       (p/then (send! req)
               (fn [response]
-                (println (:body response))
-                (done))))))
+                (t/is (= (get (:headers response) "Content-Length") (str (count (:body response)))))
+                (done)
+                )))))
+
+(t/deftest send-medium-binary
+  (t/async done
+    (let [uri "https://clojars.org/repo/funcool/httpurr/0.6.2/httpurr-0.6.2.jar"
+          req {:method :get
+               :url uri
+               :headers {}}]
+
+      (p/then (send! req)
+              (fn [response]
+                (t/is (= (get (:headers response) "Content-Length") (str (count (:body response)))))
+                (done)
+                )))))
 
 
 (t/deftest send-plain-get-with-query-string

--- a/test/httpurr/test/test_node_client.cljs
+++ b/test/httpurr/test/test_node_client.cljs
@@ -109,7 +109,7 @@
 
       (p/then (send! req)
               (fn [response]
-                (t/is (= (get (:headers response) "Content-Length") (str (count (:body response)))))
+                (t/is (= (get (:headers response) "Content-Length") (str (.-length (:body response)))))
                 (done)
                 )))))
 
@@ -122,7 +122,7 @@
 
       (p/then (send! req)
               (fn [response]
-                (t/is (= (get (:headers response) "Content-Length") (str (count (:body response)))))
+                (t/is (= (get (:headers response) "Content-Length") (str (.-length (:body response)))))
                 (done)
                 )))))
 

--- a/test/httpurr/test/test_node_client.cljs
+++ b/test/httpurr/test/test_node_client.cljs
@@ -15,6 +15,7 @@
 
 (def ^:private http (node/require "http"))
 (def ^:private url (node/require "url"))
+(def ^:priavte fs (node/require "fs"))
 (def ^:const port 44556)
 
 (defn- read-request
@@ -99,6 +100,20 @@
                   (t/is (= (:method lreq) :get))
                   (t/is (= (:path lreq) path))
                   (done)))))))
+
+(t/deftest send-binary
+  (t/async done
+    (let [path "/binary"
+          uri (make-uri path)
+          req {:method :get
+               :url uri
+               :headers {}}]
+
+      (p/then (send! req)
+              (fn [response]
+                (println (:body response))
+                (done))))))
+
 
 (t/deftest send-plain-get-with-query-string
   (t/async done


### PR DESCRIPTION
Here is a test case for the issue described in #16 

- when making a request to a small text file, there is no length mismatch between `Content-Length` and the actual `body` length
- when making a request to a larger binary, there is a length mismatch between `Content-Length` and the actual `body` length

This is not an issue of the server mis-reporting the content length, as can be verified with:

```
$ curl -vv https://clojars.org/repo/funcool/httpurr/0.6.2/httpurr-0.6.2.jar | wc -c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 23.253.149.7...
* TCP_NODELAY set
* Connected to clojars.org (23.253.149.7) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
* Server certificate: clojars.org
* Server certificate: RapidSSL SHA256 CA
* Server certificate: GeoTrust Global CA
> GET /repo/funcool/httpurr/0.6.2/httpurr-0.6.2.jar HTTP/1.1
> Host: clojars.org
> User-Agent: curl/7.51.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx
< Date: Sun, 21 May 2017 15:10:42 GMT
< Content-Type: application/java-archive
< Content-Length: 9830
< Last-Modified: Fri, 26 Aug 2016 08:35:36 GMT
< Connection: keep-alive
< ETag: "57bfff58-2666"
< Expires: Sun, 28 May 2017 15:10:42 GMT
< Cache-Control: max-age=604800
< Strict-Transport-Security: max-age=31536000
< Accept-Ranges: bytes
< 
{ [9830 bytes data]
* Curl_http_done: called premature == 0
100  9830  100  9830    0     0  20569      0 --:--:-- --:--:-- --:--:-- 20607
* Connection #0 to host clojars.org left intact
    9830
```

The second test case `send-medium-binary` fails as follows:

```
Testing httpurr.test.test-node-client

FAIL in (send-medium-binary) (promesa/impl.js:13:11)
expected: (= (get (:headers response) "Content-Length") (str (count (:body response))))
  actual: (not (= "9830" "9576"))
```

> The author or authors of this code dedicate any and all copyright interest
> in this code to the public domain. We make this dedication for the benefit of
> the public at large and to the detriment of our heirs and successors. We
> intend this dedication to be an overt act of relinquishment in perpetuity of
> all present and future rights to this code under copyright law.