### PR TITLE
New alternative xhr client

### DIFF
--- a/src/httpurr/client/xhr_alt.cljs
+++ b/src/httpurr/client/xhr_alt.cljs
@@ -1,0 +1,89 @@
+(ns httpurr.client.xhr-alt
+  (:refer-clojure :exclude [get])
+  (:require [httpurr.protocols]
+            [clojure.string :as str]
+            [httpurr.protocols :as p]
+            [httpurr.client :as c]))
+
+(defn normalize-headers
+  [headers]
+  (reduce-kv (fn [acc k v]
+               (assoc acc (str/lower-case k) v))
+             {} headers))
+
+(defn- parse-header-string [hs]
+  (when-not (empty? hs)
+    (->> hs
+         clojure.string/split-lines
+         (map #(clojure.string/split % ": "))
+         (into {}))))
+
+(deftype Xhr [xhr]
+  p/Request
+  (-listen [_ cb]
+    (set! (.-onreadystatechange xhr)
+          (fn []
+            (when (= (.-readyState xhr)
+                     js/XMLHttpRequest.DONE)
+              (cb (Xhr. xhr))))))
+
+  p/Response
+  (-success? [_]
+    (#{200 201 202 204 206 304 1223} (.-status xhr)))
+
+  (-response [_]
+    {:status  (.-status xhr)
+     :body    (.-response xhr)
+     :headers (-> (.getAllResponseHeaders xhr)
+                  parse-header-string
+                  (normalize-headers))})
+
+  (-error [this]
+    (ex-info "Error" {:status      (.-status xhr)
+                      :status-text (.-statusText xhr)
+                      :body        (.-response xhr)
+                      :headers     (-> (.getAllResponseHeaders xhr)
+                                       parse-header-string
+                                       (normalize-headers))})))
+
+(defn make-uri
+  [url qs qp]
+  (let [qs' (->> (clojure.string/split qs #"&")
+                 (map #(clojure.string/split % #"=")))
+        qp' (map (fn [[k v]]
+                   [(name k) v])
+                 qp)
+        query-string (->> (concat qp' qs')
+                          (apply concat)
+                          (map js/encodeURIComponent)
+                          (partition 2)
+                          (map (partial clojure.string/join "="))
+                          (clojure.string/join "&"))]
+    (str url (when-not (empty? query-string)
+               (str "?" query-string)))))
+
+(def client
+  (reify p/Client
+    (-send [_ request options]
+      (let [{:keys [timeout with-credentials?] :or {timeout 0 with-credentials? false}} options
+            {:keys [method url query-string query-params headers body]} request
+            uri (make-uri url query-string query-params)
+            method (c/keyword->method method)
+            xhr (js/XMLHttpRequest.)]
+        (.open xhr method uri)
+        (set! (.-timeout xhr) timeout)
+        (set! (.-withCredentials xhr) with-credentials?)
+        (doseq [[k v] headers]
+          (.setRequestHeader xhr k v))
+        (.send xhr body)
+        (Xhr. xhr)))))
+
+(def send! (partial c/send! client))
+(def head (partial (c/method :head) client))
+(def options (partial (c/method :options) client))
+(def get (partial (c/method :get) client))
+(def post (partial (c/method :post) client))
+(def put (partial (c/method :put) client))
+(def patch (partial (c/method :patch) client))
+(def delete (partial (c/method :delete) client))
+(def trace (partial (c/method :trace) client))

--- a/test/httpurr/test/test_xhr_alt_client.cljs
+++ b/test/httpurr/test/test_xhr_alt_client.cljs
@@ -1,0 +1,23 @@
+(ns httpurr.test.test-xhr-alt-client
+  (:require [cljs.test :as t]
+            [httpurr.client.xhr-alt :as xhr-alt]))
+
+(t/deftest make-uri-test
+  (t/testing "no question mark when no params"
+    (t/is (= (xhr-alt/make-uri "foo/bar" nil nil)
+             "foo/bar")))
+  (t/testing "question mark when params"
+    (t/is (= (xhr-alt/make-uri "foo/bar" "x=42" nil)
+             "foo/bar?x=42")))
+  (t/testing "params separated by &"
+    (t/is (= (xhr-alt/make-uri "foo/bar" nil "x=42&y=43")
+             "foo/bar?x=42&y=43")))
+  (t/testing "both key and value will be encoded"
+    (t/is (= (xhr-alt/make-uri "foo/bar" "x%=%42" nil)
+             "foo/bar?x%25=%2542")))
+  (t/testing "keywords in keys will be converted to strings"
+    (t/is (= (xhr-alt/make-uri "foo/bar" nil {:baz 43})
+             "foo/bar?baz=43")))
+  (t/testing "query params win over query string"
+    (t/is (= (xhr-alt/make-uri "foo/bar" "baz=42" {"baz" "43"})
+             "foo/bar?baz=43"))))


### PR DESCRIPTION
New XHR client for browsers, using `XMLHttpRequest` directly instead of relying on the wrapper in the Google Closure library.

The motivation stems from issues with Google's implementation on Android.

https://github.com/google/closure-library/issues/858

https://github.com/google/closure-library/issues/859

