### PR TITLE
Fix CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: clojure
-lein: lein2
+lein: lein
 jdk:
   - oraclejdk8
+  - oraclejdk9
 script:
 - ./scripts/build
 - node out/tests.js


### PR DESCRIPTION
* Fails for JDK 9 since `javax.xml.bind.DatatypeConverter` was removed in one of the dependencies. aleph issue was fixed with https://github.com/ztellman/aleph/pull/337 but not released as a stable version.