### PR TITLE
Fixed broken example.

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -440,7 +440,7 @@ is sent correctly.
 (.append fd "baz" "foo")
 
 (defn parse-json-body
-  [{:keys [body}]
+  [{:keys [body]}]
   (js/JSON.parse body))
 
 (defn clj-body


### PR DESCRIPTION
There was a missing closing square bracket in the "Sending form data" example.

> The author or authors of this code dedicate any and all copyright interest
> in this code to the public domain. We make this dedication for the benefit of
> the public at large and to the detriment of our heirs and successors. We
> intend this dedication to be an overt act of relinquishment in perpetuity of
> all present and future rights to this code under copyright law.