### PR TITLE
Document with-credentials?

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -63,8 +63,13 @@ with `httpurr`, note that this client will only work on browser environments:
              :url "https://api.github.com/orgs/funcool"})
 ----
 
-The options map accepts a `:timeout`, in miliseconds, after which the promise will
-be rejected with the `:timeout` keyword as a value.
+The options map accepts the following keys:
+
+ - `:timeout`: A time, specified in miliseconds, after which the promise will
+   be rejected with the `:timeout` keyword as a value.
+ - `:with-credentials?`: A boolean, defaulting to false, which if true will 
+   use credentials such as cookies, authorization headers or TLS client certificates
+   during cross-site requests.
 
 Furthermore, the `httpurr.client` namespaces exposes `get`, `put`, `post`,
 `patch`, `delete`, `head`, `options` and `trace` methods with identical signatures. They


### PR DESCRIPTION
I'm not actually sure this is right, but I see that with-credentials is supported in the code so I thought it should be documented somewhere.

The author or authors of this code dedicate any and all copyright interest
in this code to the public domain. We make this dedication for the benefit of
the public at large and to the detriment of our heirs and successors. We
intend this dedication to be an overt act of relinquishment in perpetuity of
all present and future rights to this code under copyright law.