### PR TITLE
add support for clj-http-lite client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/clojurescript "1.9.225" :scope "provided"]
                  [aleph "0.4.3" :scope "provided"]
+                 [org.martinklepsch/clj-http-lite "0.4.1" :scope "provided"]
                  [org.clojure/test.check "0.9.0" :scope "test"]
                  [funcool/promesa "1.8.1"]]
 

--- a/src/httpurr/client/clj_http_lite.clj
+++ b/src/httpurr/client/clj_http_lite.clj
@@ -1,0 +1,93 @@
+(ns httpurr.client.clj-http-lite
+  (:refer-clojure :exclude [get])
+  (:require [clj-http.lite.client :as http]
+            [httpurr.client :as c]
+            [promesa.core :as fp]
+            [httpurr.protocols :as p]
+            [httpurr.status :as s])
+  (:import [java.net URI]))
+
+;; --- Client Impl.
+
+(defn- response?
+  "Check if data has valid response like format."
+  [data]
+  (and (map? data)
+       (s/status-code? (:status data 0))))
+
+(deftype HttpResponse [http-response]
+  p/Response
+  (-success? [_]
+    true)
+  (-response [_]
+    http-response))
+
+(deftype HttpErrorResponse [error]
+  p/Response
+  (-success? [_]
+    false)
+  (-error [_]
+    error))
+
+(deftype HttpRequest [future-response]
+  p/Request
+  (-listen [_ callback]
+    (callback
+      (try
+        (let [response @future-response]
+          (HttpResponse. response))
+        (catch Throwable e
+          (let [data (or (ex-data e) (ex-data (.getCause e)))]
+            (if (response? data)
+              (HttpResponse. data)
+              (HttpErrorResponse. e))))))))
+
+(defn- make-uri
+  [url query-string]
+  (if (not query-string)
+    url
+    (let [^URI uri (URI. url)
+          idx (.indexOf url "?")
+          ^String query (if (>= idx 0)
+                          (str (.getQuery uri) "&" query-string)
+                          query-string)
+          ^URI uri-w-query (URI. (.getScheme uri)
+                                 (.getUserInfo uri)
+                                 (.getHost uri)
+                                 (.getPort uri)
+                                 (.getPath uri)
+                                 query   
+                                 (.getFragment uri))]
+      (.toASCIIString uri-w-query))))
+
+(deftype HttpClient [default-options]
+  p/Client
+  (-send [_ request request-options]
+    (let [{:keys [timeout] :as options} (merge default-options request-options)
+          url (make-uri (:url request) (:query-string request))
+          params (merge request
+                        options
+                        {:url url}
+                        (when timeout
+                          {:conn-timeout timeout
+                           :socket-timeout timeout}))]
+      (-> (future (http/request params))
+          (HttpRequest.)))))
+
+(defn make-http-client
+  [& {:as default-options}]
+  (HttpClient. default-options))
+
+(def client (make-http-client :as :stream :throw-exceptions false))
+
+;; --- Shortcuts
+
+(def send! (partial c/send! client))
+(def head (partial (c/method :head) client))
+(def options (partial (c/method :options) client))
+(def get (partial (c/method :get) client))
+(def post (partial (c/method :post) client))
+(def put (partial (c/method :put) client))
+(def patch (partial (c/method :patch) client))
+(def delete (partial (c/method :delete) client))
+(def trace (partial (c/method :trace) client))

--- a/test/httpurr/test/test_clj_http_lite_client.clj
+++ b/test/httpurr/test/test_clj_http_lite_client.clj
@@ -1,0 +1,169 @@
+(ns httpurr.test.test-clj-http-lite-client
+  (:require [clojure.test :as t]
+            [byte-streams :as bs]
+            [httpurr.client :as http]
+            [httpurr.client.clj-http-lite :refer [client]]
+            [aleph.http :as ahttp]
+            [promesa.core :as p]))
+
+;; --- helpers
+
+(def ^:private last-request (atom nil))
+
+(defn- send!
+  [request]
+  (http/send! client request))
+
+(defn- read-request
+  [{:keys [request-method headers uri body query-string]}]
+  {:body (when body (bs/to-string body))
+   :query query-string
+   :method request-method
+   :headers headers
+   :path uri})
+
+(defn- test-handler
+  [{:keys [body] :as request}]
+  (let [request (merge request (when body {:body (bs/to-string body)}))]
+    (reset! last-request (read-request request))
+    (if (= (:body request) "error")
+      {:status 400
+       :body (:body request)
+       :content-type "text/plain"}
+      {:status 200
+       :body (:body request)
+       :content-type "text/plain"})))
+
+(def ^:private port (atom 0))
+
+(defonce ^:private server
+  (ahttp/start-server test-handler {:port 0}))
+
+(reset! port (.port server))
+
+(defn- make-uri
+  [path]
+  (let [p @port]
+    (str "http://localhost:" p path)))
+
+;; --- tests
+
+(t/deftest send-plain-get
+  (let [path "/funcool/cats"
+        uri (make-uri path)
+        req {:method :get
+             :url uri
+             :headers {}}]
+
+    @(send! req)
+
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :get))
+      (t/is (= (:path lreq) path)))))
+
+(t/deftest send-plain-get-with-query-string
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        query "foo=bar&baz=frob"
+        req {:method :get
+             :query-string query
+             :url url}]
+
+    @(send! req)
+
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :get))
+      (t/is (= (:path lreq) path))
+      (t/is (= (:query lreq) query)))))
+
+(t/deftest send-plain-get-with-encoded-query-string
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        query "foo=b az"
+        req {:method :get
+             :query-string query
+             :url url}]
+
+    @(send! req)
+
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :get))
+      (t/is (= (:path lreq) path))
+      (t/is (= (:query lreq) (.replaceAll query " " "%20"))))))
+
+(t/deftest send-plain-get-with-encoded-query-params
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        query {:foo ["bar" "ba z"]}
+        req {:method :get
+             :query-params query
+             :url url}]
+
+    @(send! req)
+
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :get))
+      (t/is (= (:path lreq) path))
+      (t/is (= (:query lreq) "foo=bar&foo=ba+z")))))
+
+(t/deftest send-plain-get-with-custom-header
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        req {:method :get
+             :url url
+             :headers {"Content-Type" "application/json"}}]
+
+    @(send! req)
+
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :get))
+      (t/is (= (:path lreq) path))
+      (t/is (= (get-in lreq [:headers "content-type"])
+               "application/json")))))
+
+(t/deftest send-request-with-body
+  (let [path "/funcool/promesa"
+        url (make-uri path)
+        content "yada yada yada"
+        ctype "text/plain"
+        req {:method :post
+             :url url
+             :headers {"content-type" ctype}
+             :body content}]
+
+    (let [response @(send! req)
+          lreq @last-request]
+      (t/is (= (:method lreq) :post))
+      (t/is (= (:path lreq) path))
+      (t/is (= content (slurp (:body response)))))))
+
+(t/deftest send-returns-a-promise
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        req {:method :get
+             :url url}
+        resp (send! req)]
+    (t/is (p/promise? resp))))
+
+(t/deftest send-returns-response-map-on-success
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        req {:method :get
+             :url url}
+        resp @(send! req)]
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :get))
+      (t/is (= (:path lreq) path))
+      (t/is (= 200 (:status resp))))))
+
+(t/deftest send-returns-response-failure
+  (let [path "/funcool/cats"
+        url (make-uri path)
+        req {:method :post
+             :body "error"
+             :url url}
+        resp  @(send! req)]
+    (let [lreq @last-request]
+      (t/is (= (:method lreq) :post))
+      (t/is (= (:path lreq) path))
+      (t/is (= 400 (:status resp))))))


### PR DESCRIPTION
This PR adds support for `clj-http-lite` client, which is supported for GraalVM native compilation.

```
The author or authors of this code dedicate any and all copyright interest
in this code to the public domain. We make this dedication for the benefit of
the public at large and to the detriment of our heirs and successors. We
intend this dedication to be an overt act of relinquishment in perpetuity of
all present and future rights to this code under copyright law.
```