### PR TITLE
upgrade to promesa 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog #
 
+## Unreleased ## 
+
+- Upgrade [promesa](https://github.com/funcool/promesa/blob/master/CHANGELOG.md#version-402)
+  to v4
+
 ## Version 1.1.0 ##
 
 Date: 2018-06-02

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [aleph "0.4.3" :scope "provided"]
                  [org.martinklepsch/clj-http-lite "0.4.1" :scope "provided"]
                  [org.clojure/test.check "0.9.0" :scope "test"]
-                 [funcool/promesa "1.8.1"]]
+                 [funcool/promesa "4.0.2"]]
 
   :profiles
   {:dev

--- a/src/httpurr/client.cljc
+++ b/src/httpurr/client.cljc
@@ -27,7 +27,7 @@
   response and rejected on timeout, exceptions, HTTP errors
   or abortions."
   [request]
-  (p/promise
+  (p/create
    (fn [resolve reject]
      (proto/-listen request
                     (fn [resp]


### PR DESCRIPTION
I think the promise constructor change is the only breaking change impacting httpurr.