### PR TITLE
Update Travis configuration to fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: clojure
 lein: lein
+dist: trusty
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
+  - openjdk11
 script:
 - ./scripts/build
 - node out/tests.js


### PR DESCRIPTION
Travis builds were not working for either JDK 8 or JDK 9.

1. JDK 8 builds were breaking because Travis now defaults to using Xenial unless specified and this release does not include any support for JDK 8. The solution is to specify the distribution as `trusty` (see discussion [here](https://travis-ci.community/t/expected-feature-release-number-in-range-of-9-to-12-but-got-8-installing-oraclejdk8/1345/8)).

2. JDK 9 builds were breaking because Oracle no longer allows for direct downloads and so Travis switched to OpenJDK. This has SSL issues with JDK 9 and JDK 10. The solution was to use JDK 11 (see discussion [here](https://github.com/travis-ci/travis-ci/issues/9368)).

It seems it is possible to test against JDK 9 by following the instructions [here](https://www.deps.co/guides/travis-ci-latest-java/). Is that something we want to do? Or is JDK 8 and 11 sufficient?