### PR TITLE
Use jscdn's asciidoctor stylesheet

### DIFF
--- a/latest/index.html
+++ b/latest/index.html
@@ -79,7 +79,7 @@
 .listingblock .pygments .tok-il { color: #40a070 } /* Literal.Number.Integer.Long */
 </style>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Liberation+Mono:400|Roboto+Slab:400,700"/>
-<link rel="stylesheet" href="https://www.niwi.nz/_assets/asciidoctor-styles/simple-red-titles/stylesheet.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/asciidoctor.js/1.5.5-5/css/asciidoctor.min.css"/>
 </head>
 <body class="article toc2 toc-left">
 <div id="header">


### PR DESCRIPTION
I noticed a handful of funcool's docs pages had broken styling,
this should patch things up!